### PR TITLE
Automatically switch to the teleop at the end of autonomous.

### DIFF
--- a/TeamCode/src/main/java/suitbots/opmode/ExampleAutonomous.java
+++ b/TeamCode/src/main/java/suitbots/opmode/ExampleAutonomous.java
@@ -1,0 +1,25 @@
+package suitbots.opmode;
+
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+
+import org.firstinspires.ftc.robotcore.internal.opmode.OpModeManagerImpl;
+
+@Autonomous(name = "AUTO")
+public class ExampleAutonomous extends LinearOpMode {
+    @Override
+    public void runOpMode() throws InterruptedException {
+        telemetry.addData("State", "Waiting for start");
+        telemetry.update();
+        waitForStart();
+        final long t0 = System.currentTimeMillis();
+        while (opModeIsActive()) {
+            final long t1 = System.currentTimeMillis();
+            final long dt = t1 - t0;
+            telemetry.addData("State", "Running " + dt);
+            telemetry.update();
+        }
+
+        ((OpModeManagerImpl)internalOpModeServices).initActiveOpMode("TELEOP");
+    }
+}

--- a/TeamCode/src/main/java/suitbots/opmode/ExampleTeleop.java
+++ b/TeamCode/src/main/java/suitbots/opmode/ExampleTeleop.java
@@ -1,0 +1,17 @@
+package suitbots.opmode;
+
+import com.qualcomm.robotcore.eventloop.opmode.OpMode;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+
+@TeleOp(name = "TELEOP")
+public class ExampleTeleop extends OpMode {
+    @Override
+    public void init() {
+
+    }
+
+    @Override
+    public void loop() {
+
+    }
+}


### PR DESCRIPTION
This year, there are only 5 seconds between autonomous and teleop. This code will automatically switch from the autonomous to the teleop. Maybe useful. Maybe dangerous. Here it is either way. Yours to do with as you see fit.

The `initActiveOpMode` line is the only one that really matters. Everything else here is just boilerplate to get two OpModes up and going.