### PR TITLE
Clean up the vision system example

### DIFF
--- a/TeamCode/src/main/java/suitbots/Robot.java
+++ b/TeamCode/src/main/java/suitbots/Robot.java
@@ -36,10 +36,6 @@ public class Robot {
         initilizeGyro();
         lineDetector = h.colorSensor.get("lineDetector");
 
-        //pf = new LazyCR(hardwareMap.crservo.get("pf"));
-        //pr = new LazyCR(hardwareMap.crservo.get("pr"));
-
-
         lf = h.dcMotor.get("lf");
         lr = h.dcMotor.get("lr");
         rf = h.dcMotor.get("rf");

--- a/TeamCode/src/main/java/suitbots/opmode/SampleVision.java
+++ b/TeamCode/src/main/java/suitbots/opmode/SampleVision.java
@@ -2,9 +2,7 @@ package suitbots.opmode;
 
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
-import com.suitbots.util.Controller;
 
-import suitbots.Robot;
 import suitbots.VisionTargets;
 
 @TeleOp(name = "Fill your eyes....")

--- a/TeamCode/src/main/java/suitbots/opmode/SampleVision.java
+++ b/TeamCode/src/main/java/suitbots/opmode/SampleVision.java
@@ -2,7 +2,9 @@ package suitbots.opmode;
 
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+import com.suitbots.util.Controller;
 
+import suitbots.Robot;
 import suitbots.VisionTargets;
 
 @TeleOp(name = "Fill your eyes....")
@@ -12,7 +14,7 @@ public class SampleVision extends OpMode {
     @Override
     public void init() {
         vt = new VisionTargets();
-        vt.initBackCamera(this);
+        vt.initFrontCamera(this);
     }
 
     @Override
@@ -23,9 +25,9 @@ public class SampleVision extends OpMode {
             telemetry.addData("TX", vt.getTranslationX());
             telemetry.addData("TY", vt.getTranslationY());
             telemetry.addData("TZ", vt.getTranslationZ());
-            telemetry.addData("RX", vt.getRotationX());
-            telemetry.addData("RY", vt.getRotationY());
-            telemetry.addData("RZ", vt.getRotationZ());
+            telemetry.addData("RX", Math.toDegrees(vt.getRotationX()));
+            telemetry.addData("RY", Math.toDegrees(vt.getRotationY()));
+            telemetry.addData("RZ", Math.toDegrees(vt.getRotationZ()));
         } else {
             telemetry.clear();
             telemetry.addData("Vision", "Zero");


### PR DESCRIPTION
Use the front camera and print angles for human consumption in degrees rather than angles.

This sample revealed that the Y axis gives us robot orientation that can be used for alignment during autonomous. 